### PR TITLE
Reduce code duplication

### DIFF
--- a/core-csp/src/main/java/io/activej/csp/ChannelInput.java
+++ b/core-csp/src/main/java/io/activej/csp/ChannelInput.java
@@ -16,14 +16,9 @@
 
 package io.activej.csp;
 
-import io.activej.csp.dsl.ChannelSupplierTransformer;
 import io.activej.csp.queue.ChannelQueue;
 import io.activej.csp.queue.ChannelZeroBuffer;
 import io.activej.promise.Promise;
-
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
 
 @FunctionalInterface
 public interface ChannelInput<T> {
@@ -36,26 +31,6 @@ public interface ChannelInput<T> {
 	default ChannelConsumer<T> getConsumer(ChannelQueue<T> queue) {
 		Promise<Void> extraAcknowledge = set(queue.getSupplier());
 		return queue.getConsumer(extraAcknowledge);
-	}
-
-	default <R> ChannelInput<R> transformWith(ChannelSupplierTransformer<R, ChannelSupplier<T>> fn) {
-		return input -> set(fn.transform(input));
-	}
-
-	default <R> ChannelInput<R> map(Function<? super R, ? extends T> fn) {
-		return input -> set(input.map(fn));
-	}
-
-	default <R> ChannelInput<R> mapAsync(Function<? super R, ? extends Promise<T>> fn) {
-		return input -> set(input.mapAsync(fn));
-	}
-
-	default ChannelInput<T> filter(Predicate<? super T> predicate) {
-		return input -> set(input.filter(predicate));
-	}
-
-	default ChannelInput<T> peek(Consumer<? super T> peek) {
-		return input -> set(input.peek(peek));
 	}
 
 }

--- a/core-csp/src/main/java/io/activej/csp/ChannelOutput.java
+++ b/core-csp/src/main/java/io/activej/csp/ChannelOutput.java
@@ -16,22 +16,13 @@
 
 package io.activej.csp;
 
-import io.activej.csp.dsl.ChannelConsumerTransformer;
 import io.activej.csp.queue.ChannelQueue;
 import io.activej.csp.queue.ChannelZeroBuffer;
 import io.activej.promise.Promise;
 
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-
 @FunctionalInterface
 public interface ChannelOutput<T> {
 	void set(ChannelConsumer<T> output);
-
-	default void set(Promise<ChannelConsumer<T>> outputPromise) {
-		set(ChannelConsumer.ofPromise(outputPromise));
-	}
 
 	default ChannelSupplier<T> getSupplier() {
 		return getSupplier(new ChannelZeroBuffer<>());
@@ -40,26 +31,6 @@ public interface ChannelOutput<T> {
 	default ChannelSupplier<T> getSupplier(ChannelQueue<T> queue) {
 		set(queue.getConsumer());
 		return queue.getSupplier();
-	}
-
-	default <R> ChannelOutput<R> transformWith(ChannelConsumerTransformer<R, ChannelConsumer<T>> fn) {
-		return output -> set(output.transformWith(fn));
-	}
-
-	default <R> ChannelOutput<R> map(Function<? super T, ? extends R> fn) {
-		return output -> set(output.map(fn));
-	}
-
-	default <R> ChannelOutput<R> mapAsync(Function<? super T, ? extends Promise<R>> fn) {
-		return output -> set(output.mapAsync(fn));
-	}
-
-	default ChannelOutput<T> filter(Predicate<? super T> predicate) {
-		return output -> set(output.filter(predicate));
-	}
-
-	default ChannelOutput<T> peek(Consumer<? super T> peek) {
-		return output -> set(output.peek(peek));
 	}
 
 	default Promise<Void> bindTo(ChannelInput<T> to) {

--- a/core-csp/src/main/java/io/activej/csp/process/AbstractChannelTransformer.java
+++ b/core-csp/src/main/java/io/activej/csp/process/AbstractChannelTransformer.java
@@ -16,7 +16,10 @@
 
 package io.activej.csp.process;
 
-import io.activej.csp.*;
+import io.activej.csp.ChannelConsumer;
+import io.activej.csp.ChannelInput;
+import io.activej.csp.ChannelOutput;
+import io.activej.csp.ChannelSupplier;
 import io.activej.csp.dsl.WithChannelTransformer;
 import io.activej.promise.Promise;
 import org.jetbrains.annotations.NotNull;
@@ -56,16 +59,12 @@ public abstract class AbstractChannelTransformer<S extends AbstractChannelTransf
 
 	@Override
 	protected void doProcess() {
-		onProcessStart()
-				.whenComplete(($, e) -> {
-					if (e == null) {
-						input.streamTo(ChannelConsumer.of(this::onItem))
-								.then(this::onProcessFinish)
-								.whenResult(this::completeProcess);
-					} else {
-						closeEx(e);
-					}
-				});
+		Promise.complete()
+				.then(this::onProcessStart)
+				.then(() -> input.streamTo(ChannelConsumer.of(this::onItem)))
+				.then(this::onProcessFinish)
+				.whenResult(this::completeProcess)
+				.whenException(this::closeEx);
 	}
 
 	@SuppressWarnings("ConstantConditions")

--- a/core-csp/src/main/java/io/activej/csp/process/ChannelByteChunker.java
+++ b/core-csp/src/main/java/io/activej/csp/process/ChannelByteChunker.java
@@ -62,9 +62,7 @@ public final class ChannelByteChunker extends AbstractChannelTransformer<Channel
 
 	@Override
 	protected Promise<Void> onProcessFinish() {
-		return bufs.hasRemaining() ?
-				send(bufs.takeRemaining())
-						.then(this::sendEndOfStream) :
-				sendEndOfStream();
+		return (bufs.hasRemaining() ? send(bufs.takeRemaining()) : Promise.complete())
+				.then(this::sendEndOfStream);
 	}
 }

--- a/core-inject/src/main/java/io/activej/inject/Injector.java
+++ b/core-inject/src/main/java/io/activej/inject/Injector.java
@@ -36,13 +36,13 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static io.activej.inject.Scope.UNSCOPED;
-import static io.activej.inject.binding.BindingGenerator.REFUSING;
 import static io.activej.inject.binding.BindingGenerator.combinedGenerator;
-import static io.activej.inject.binding.BindingTransformer.IDENTITY;
+import static io.activej.inject.binding.BindingGenerator.refusing;
 import static io.activej.inject.binding.BindingTransformer.combinedTransformer;
+import static io.activej.inject.binding.BindingTransformer.identity;
 import static io.activej.inject.binding.BindingType.*;
-import static io.activej.inject.binding.Multibinder.ERROR_ON_DUPLICATE;
 import static io.activej.inject.binding.Multibinder.combinedMultibinder;
+import static io.activej.inject.binding.Multibinder.errorOnDuplicate;
 import static io.activej.inject.impl.CompiledBinding.missingOptionalBinding;
 import static io.activej.inject.util.Utils.getScopeDisplayString;
 import static io.activej.inject.util.Utils.next;
@@ -157,9 +157,9 @@ public final class Injector implements ResourceLocator {
 	public static Injector of(@NotNull Trie<Scope, Map<Key<?>, Binding<?>>> bindings) {
 		return compile(null, UNSCOPED,
 				bindings.map(map -> map.entrySet().stream().collect(toMap(Entry::getKey, entry -> new BindingSet<>(singleton(entry.getValue()), REGULAR)))),
-				ERROR_ON_DUPLICATE,
-				IDENTITY,
-				REFUSING);
+				errorOnDuplicate(),
+				identity(),
+				refusing());
 	}
 
 	/**

--- a/core-inject/src/main/java/io/activej/inject/binding/Binding.java
+++ b/core-inject/src/main/java/io/activej/inject/binding/Binding.java
@@ -43,7 +43,7 @@ import static java.util.stream.Collectors.toSet;
  * Also it contains a set of {@link io.activej.inject.module.AbstractModule binding-DSL-like} static factory methods
  * as well as some functional transformations for the ease of creating immutable binding modifications.
  */
-@SuppressWarnings({"unused", "WeakerAccess", "ArraysAsListWithZeroOrOneArgument", "Convert2Lambda"})
+@SuppressWarnings({"unused", "WeakerAccess", "ArraysAsListWithZeroOrOneArgument", "Convert2Lambda", "rawtypes"})
 public final class Binding<T> {
 	private final Set<Dependency> dependencies;
 	private final BindingCompiler<T> compiler;

--- a/core-inject/src/main/java/io/activej/inject/binding/BindingGenerator.java
+++ b/core-inject/src/main/java/io/activej/inject/binding/BindingGenerator.java
@@ -39,16 +39,13 @@ import static java.util.stream.Collectors.toSet;
  */
 @FunctionalInterface
 public interface BindingGenerator<T> {
-	BindingGenerator<Object> REFUSING = (bindings, scope, key) -> null;
-
 	@Nullable Binding<T> generate(BindingLocator bindings, Scope[] scope, Key<T> key);
 
 	/**
 	 * Default generator that never generates anything.
 	 */
-	@SuppressWarnings("unchecked")
 	static <T> BindingGenerator<T> refusing() {
-		return (BindingGenerator<T>) REFUSING;
+		return (bindings, scope, key) -> null;
 	}
 
 	/**

--- a/core-inject/src/main/java/io/activej/inject/binding/BindingTransformer.java
+++ b/core-inject/src/main/java/io/activej/inject/binding/BindingTransformer.java
@@ -34,13 +34,10 @@ import static java.util.stream.Collectors.toList;
  */
 @FunctionalInterface
 public interface BindingTransformer<T> {
-	BindingTransformer<?> IDENTITY = (bindings, scope, key, binding) -> binding;
-
 	@NotNull Binding<T> transform(BindingLocator bindings, Scope[] scope, Key<T> key, Binding<T> binding);
 
-	@SuppressWarnings("unchecked")
 	static <T> BindingTransformer<T> identity() {
-		return (BindingTransformer<T>) IDENTITY;
+		return (bindings, scope, key, binding) -> binding;
 	}
 
 	/**

--- a/core-inject/src/main/java/io/activej/inject/binding/BindingType.java
+++ b/core-inject/src/main/java/io/activej/inject/binding/BindingType.java
@@ -25,10 +25,12 @@ public enum BindingType {
 	 * Such binding has no special properties and behaves like a lazy singleton, this is the default
 	 */
 	REGULAR,
+
 	/**
 	 * Such binding has no cache slot and each time <code>getInstance</code> is called, a new instance of the object is created
 	 */
 	TRANSIENT,
+
 	/**
 	 * Such binding behaves like eager singleton - instance is created and placed in the cache at the moment of injector creation
 	 */


### PR DESCRIPTION
Reduced some of the verbose code in Binding.java by extracting the various part into lambdas.

I did a very simple perfomance check based on the test _DIFollowUpTest.moduleBuilderWithQualifiedBindsSnippet_ and found out, that the changes have some performance impact on the creation of the Injector
ModuleBuilder.create()...
Injector injector = Injector.of(cookbook);
of about 5-10%, but I couldn't measure any increase of time for the execution of the injector.getInstance() method. So this change might have a little impact on the startup time, but as far as I can see no impact on the runtime. I'm pretty sure that this change makes this class much more maintainable.