### PR TITLE
Allow Users to rename the BinarySerializers Class name.

### DIFF
--- a/core-serializer/src/main/java/io/activej/serializer/SerializerBuilder.java
+++ b/core-serializer/src/main/java/io/activej/serializer/SerializerBuilder.java
@@ -65,6 +65,7 @@ public final class SerializerBuilder {
 	private final TypeScannerRegistry<SerializerDef> registry = TypeScannerRegistry.create();
 
 	private String profile;
+	private String className;
 	private int encodeVersionMax = Integer.MAX_VALUE;
 	private int decodeVersionMin = 0;
 	private int decodeVersionMax = Integer.MAX_VALUE;
@@ -280,6 +281,11 @@ public final class SerializerBuilder {
 		extraSubclassesMap.put(type, (List) subclasses);
 	}
 
+	public SerializerBuilder setClassName(String className) {
+		this.className = className;
+		return this;
+	}
+
 	public <T> BinarySerializer<T> build(Type type) {
 		return build(annotatedTypeOf(type));
 	}
@@ -295,6 +301,8 @@ public final class SerializerBuilder {
 		if (saveBytecodePath != null) {
 			classBuilder.withBytecodeSaveDir(saveBytecodePath);
 		}
+		if(className != null)
+			classBuilder.withClassName(className);
 
 		Set<Integer> collectedVersions = new HashSet<>();
 		Map<Object, Expression> encoderInitializers = new HashMap<>();


### PR DESCRIPTION
Allow users to rename the Class Name of the serializer that SerializerBuilder creates. This is helpful for people like me where we output all serializers into the bytecode path and then reuse that .class, This change would prevent people like me from needing to rename the serializer file after the fact and then decode what its original name was.