### PR TITLE
Do not enforce .class on bytecode output path.

### DIFF
--- a/core-codegen/src/main/java/io/activej/codegen/ClassBuilder.java
+++ b/core-codegen/src/main/java/io/activej/codegen/ClassBuilder.java
@@ -430,7 +430,7 @@ public final class ClassBuilder<T> implements WithInitializer<ClassBuilder<T>> {
 
 		if (bytecodeSaveDir != null) {
 			String classFileName = customClassName != null ? actualClassName : actualClassName.substring(PACKAGE_PREFIX.length());
-			try (FileOutputStream fos = new FileOutputStream(bytecodeSaveDir.resolve(classFileName + ".class").toFile())) {
+			try (FileOutputStream fos = new FileOutputStream(bytecodeSaveDir.resolve(classFileName).toFile())) {
 				fos.write(cw.toByteArray());
 			} catch (IOException e) {
 				throw new RuntimeException(e);


### PR DESCRIPTION
The output path should actually be the output path and not the file name with an enforced extension just so developers can have custom file extentions.