### PR TITLE
Fix file comparison in tests of FS invariants

### DIFF
--- a/cloud-fs/src/test/java/io/activej/fs/Utils.java
+++ b/cloud-fs/src/test/java/io/activej/fs/Utils.java
@@ -139,7 +139,7 @@ public final class Utils {
 		try {
 			List<Path> subPaths;
 			try (Stream<Path> list = Files.list(directoryPath)) {
-				subPaths = list.collect(toList());
+				subPaths = list.sorted().collect(toList());
 			}
 			for (Path path : subPaths) {
 				if (Files.isRegularFile(path)) {


### PR DESCRIPTION
Sort directory entries to compare the respective files from the first and second directory. Directory entries returned by `Files#list` are in no particular order.

Could be related to the OS. I'm on `Linux desktop 5.15.12-arch1-1 #1 SMP PREEMPT Wed, 29 Dec 2021 12:04:56 +0000 x86_64 GNU/Linux`.