### PR TITLE
Allow binding to port number zero

### DIFF
--- a/boot-config/src/test/java/io/activej/config/converter/ConfigConvertersTest.java
+++ b/boot-config/src/test/java/io/activej/config/converter/ConfigConvertersTest.java
@@ -128,15 +128,18 @@ public class ConfigConvertersTest {
 		map.put("key1", Config.ofValue("192.168.1.1:80"));
 		map.put("key2", Config.ofValue("250.200.100.50:10000"));
 		map.put("key3", Config.ofValue("1.0.0.0:65000"));
+		map.put("key4", Config.ofValue("127.0.0.1:0"));
 
 		Config root = Config.ofConfigs(map);
 
 		InetSocketAddress address1 = new InetSocketAddress(InetAddress.getByName("192.168.1.1"), 80);
 		InetSocketAddress address2 = new InetSocketAddress(InetAddress.getByName("250.200.100.50"), 10000);
 		InetSocketAddress address3 = new InetSocketAddress(InetAddress.getByName("1.0.0.0"), 65000);
+		InetSocketAddress address4 = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0);
 		assertEquals(address1, inetSocketAddressConverter.get(root.getChild("key1")));
 		assertEquals(address2, inetSocketAddressConverter.get(root.getChild("key2")));
 		assertEquals(address3, inetSocketAddressConverter.get(root.getChild("key3")));
+		assertEquals(address4, inetSocketAddressConverter.get(root.getChild("key4")));
 	}
 
 	@Test

--- a/core-http/src/main/java/io/activej/http/AsyncHttpServer.java
+++ b/core-http/src/main/java/io/activej/http/AsyncHttpServer.java
@@ -324,8 +324,8 @@ public final class AsyncHttpServer extends AbstractServer<AsyncHttpServer> {
 
 	public List<String> getHttpAddresses() {
 		return Stream.concat(
-				listenAddresses.stream().map(address -> format(address, false)),
-				sslListenAddresses.stream().map(address -> format(address, true))
+				getBoundAddresses().stream().map(address -> format(address, false)),
+				getSslBoundAddresses().stream().map(address -> format(address, true))
 		).collect(toList());
 	}
 

--- a/core-http/src/main/java/io/activej/http/AsyncHttpServer.java
+++ b/core-http/src/main/java/io/activej/http/AsyncHttpServer.java
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.InetAddress;
-import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.List;
 import java.util.stream.Stream;
@@ -312,20 +311,10 @@ public final class AsyncHttpServer extends AbstractServer<AsyncHttpServer> {
 		}
 	}
 
-	private static String format(InetSocketAddress address, boolean ssl) {
-		return (ssl ? "https://" : "http://") +
-				("0.0.0.0".equals(address.getHostName())
-						? "localhost"
-						: address.getHostName()) +
-				(address.getPort() != (ssl ? 443 : 80) ?
-						":" + address.getPort()
-						: "") + "/";
-	}
-
 	public List<String> getHttpAddresses() {
 		return Stream.concat(
-				getBoundAddresses().stream().map(address -> format(address, false)),
-				getSslBoundAddresses().stream().map(address -> format(address, true))
+				getBoundAddresses().stream().map(address -> HttpUtils.formatUrl(address, false)),
+				getSslBoundAddresses().stream().map(address -> HttpUtils.formatUrl(address, true))
 		).collect(toList());
 	}
 

--- a/core-http/src/main/java/io/activej/http/HttpUtils.java
+++ b/core-http/src/main/java/io/activej/http/HttpUtils.java
@@ -21,6 +21,9 @@ import io.activej.common.exception.MalformedDataException;
 import io.activej.http.WebSocket.Frame.FrameType;
 import io.activej.http.WebSocket.Message.MessageType;
 import io.activej.http.WebSocketConstants.OpCode;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.UnsupportedEncodingException;
@@ -368,6 +371,29 @@ public final class HttpUtils {
 				return "505. HTTP Version Not Supported";
 			default:
 				return code + ". Unknown HTTP code, returned from an error";
+		}
+	}
+
+	/**
+	 * Format an IPv4/IPv6 socket address as either HTTP or HTTPS URL.
+	 *
+	 * @return the URL
+	 */
+	public static String formatUrl(InetSocketAddress address, boolean ssl) {
+		return (ssl ? "https://" : "http://")
+				+ formatHost(address.getAddress())
+				+ (address.getPort() != (ssl ? 443 : 80) ? ":" + address.getPort() : "")
+				+ "/";
+	}
+
+	private static String formatHost(InetAddress address) {
+		String name = address.getHostName();
+		if (address instanceof Inet4Address) {
+			return name;
+		} else if (address instanceof Inet6Address && name.contains(":")) {
+			return "[" + name + "]";
+		} else {
+			return name;
 		}
 	}
 

--- a/core-http/src/test/java/io/activej/http/HttpUtilsTest.java
+++ b/core-http/src/test/java/io/activej/http/HttpUtilsTest.java
@@ -7,6 +7,7 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Random;
 
@@ -83,6 +84,66 @@ public class HttpUtilsTest {
 		byte[] bytes = text.getBytes();
 		assertNegativeSizeException(() -> HttpUtils.trimAndDecodePositiveInt(bytes, 15, 3));
 		assertNegativeSizeException(() -> HttpUtils.trimAndDecodePositiveInt(bytes, 16, 2));
+	}
+
+	@Test
+	public void testFormatUrl() {
+		testFormatUrl(
+				new InetSocketAddress("localhost", 80),
+				"http://localhost/",
+				"https://localhost:80/");
+		testFormatUrl(
+				new InetSocketAddress("localhost", 443),
+				"http://localhost:443/",
+				"https://localhost/");
+		testFormatUrl(
+				new InetSocketAddress("localhost", 1337),
+				"http://localhost:1337/",
+				"https://localhost:1337/");
+
+		testFormatUrl(
+				new InetSocketAddress("0", 80),
+				"http://0.0.0.0/",
+				"https://0.0.0.0:80/");
+		testFormatUrl(
+				new InetSocketAddress("0", 443),
+				"http://0.0.0.0:443/",
+				"https://0.0.0.0/");
+		testFormatUrl(
+				new InetSocketAddress("0", 1337),
+				"http://0.0.0.0:1337/",
+				"https://0.0.0.0:1337/");
+
+		testFormatUrl(
+				new InetSocketAddress("::1", 80),
+				"http://localhost/",
+				"https://localhost:80/");
+		testFormatUrl(
+				new InetSocketAddress("::1", 443),
+				"http://localhost:443/",
+				"https://localhost/");
+		testFormatUrl(
+				new InetSocketAddress("::1", 1337),
+				"http://localhost:1337/",
+				"https://localhost:1337/");
+
+		testFormatUrl(
+				new InetSocketAddress("::", 80),
+				"http://[0:0:0:0:0:0:0:0]/",
+				"https://[0:0:0:0:0:0:0:0]:80/");
+		testFormatUrl(
+				new InetSocketAddress("::", 443),
+				"http://[0:0:0:0:0:0:0:0]:443/",
+				"https://[0:0:0:0:0:0:0:0]/");
+		testFormatUrl(
+				new InetSocketAddress("::", 1337),
+				"http://[0:0:0:0:0:0:0:0]:1337/",
+				"https://[0:0:0:0:0:0:0:0]:1337/");
+	}
+
+	private void testFormatUrl(InetSocketAddress address, String expectedUrl, String expectedSslUrl) {
+		assertEquals(expectedUrl, HttpUtils.formatUrl(address, false));
+		assertEquals(expectedSslUrl, HttpUtils.formatUrl(address, true));
 	}
 
 	// region helpers

--- a/core-net/src/test/java/io/activej/net/AbstractServerTest.java
+++ b/core-net/src/test/java/io/activej/net/AbstractServerTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.time.Duration;
+import java.util.List;
 import java.util.Objects;
 
 import static io.activej.eventloop.Eventloop.getCurrentEventloop;
@@ -22,6 +23,7 @@ import static io.activej.promise.TestUtils.await;
 import static io.activej.test.TestUtils.getFreePort;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public final class AbstractServerTest {
 	@ClassRule
@@ -53,7 +55,62 @@ public final class AbstractServerTest {
 				.withAcceptOnce()
 				.listen();
 
-		ByteBuf response = await(AsyncTcpSocketNio.connect(address)
+		ByteBuf response = sendMessage(address, message);
+		assertEquals(message, response.asString(UTF_8));
+	}
+
+	@Test
+	public void testBoundAddressPortZero() throws IOException {
+		InetSocketAddress address = new InetSocketAddress("localhost", 0);
+		AbstractServer<?> server = createServer(address);
+
+		server.listen();
+
+		List<InetSocketAddress> boundAddresses = server.getBoundAddresses();
+		assertEquals(1, boundAddresses.size());
+		assertNotEquals(server.getListenAddresses(), boundAddresses);
+
+		InetSocketAddress boundAddress = boundAddresses.get(0);
+		assertNotEquals(0, boundAddress.getPort());
+
+		String message = "Hello!";
+		ByteBuf response = sendMessage(boundAddress, message);
+		assertEquals(message, response.asString(UTF_8));
+	}
+
+	@Test
+	public void testBoundAddressPortNonZero() throws IOException {
+		InetSocketAddress address = new InetSocketAddress("localhost", getFreePort());
+		AbstractServer<?> server = createServer(address);
+
+		server.listen();
+
+		List<InetSocketAddress> boundAddresses = server.getBoundAddresses();
+		assertEquals(1, boundAddresses.size());
+		assertEquals(server.getListenAddresses(), boundAddresses);
+
+		String message = "Hello!";
+		ByteBuf response = sendMessage(boundAddresses.get(0), message);
+		assertEquals(message, response.asString(UTF_8));
+	}
+
+	private static AbstractServer<?> createServer(InetSocketAddress address) {
+		return SimpleServer.create(
+						socket -> Promises.repeat(
+								() -> socket.read().whenResult(
+												buf -> socket.write(buf).whenComplete(() -> {
+													if (buf == null) {
+														socket.close();
+													}
+												})
+										)
+										.map(Objects::nonNull)))
+				.withListenAddress(address)
+				.withAcceptOnce();
+	}
+
+	private static ByteBuf sendMessage(InetSocketAddress address, String message) {
+		return await(AsyncTcpSocketNio.connect(address)
 				.then(socket ->
 						socket.write(ByteBufStrings.wrapAscii(message))
 								.then(() -> socket.write(null))
@@ -66,7 +123,5 @@ public final class AbstractServerTest {
 											.map($2 -> bufs.takeRemaining());
 								})
 								.whenComplete(socket::close)));
-
-		assertEquals(message, response.asString(UTF_8));
 	}
 }

--- a/launchers/http/src/main/java/io/activej/launchers/http/HttpServerLauncher.java
+++ b/launchers/http/src/main/java/io/activej/launchers/http/HttpServerLauncher.java
@@ -46,6 +46,7 @@ import static io.activej.launchers.initializers.Initializers.ofHttpServer;
  * @see Launcher
  */
 public abstract class HttpServerLauncher extends Launcher {
+	public static final int PORT = 8080;
 	public static final String PROPERTIES_FILE = "http-server.properties";
 
 	@Inject
@@ -67,7 +68,7 @@ public abstract class HttpServerLauncher extends Launcher {
 	@Provides
 	Config config() {
 		return Config.create()
-				.with("http.listenAddresses", Config.ofValue(ofInetSocketAddress(), new InetSocketAddress(8080)))
+				.with("http.listenAddresses", Config.ofValue(ofInetSocketAddress(), new InetSocketAddress(PORT)))
 				.overrideWith(ofClassPathProperties(PROPERTIES_FILE, true))
 				.overrideWith(ofSystemProperties("config"));
 	}

--- a/launchers/http/src/main/java/io/activej/launchers/http/HttpServerLauncher.java
+++ b/launchers/http/src/main/java/io/activej/launchers/http/HttpServerLauncher.java
@@ -92,7 +92,9 @@ public abstract class HttpServerLauncher extends Launcher {
 
 	@Override
 	protected void run() throws Exception {
-		logger.info("HTTP Server is now available at {}", String.join(", ", httpServer.getHttpAddresses()));
+		if (logger.isInfoEnabled()) {
+			logger.info("HTTP Server is now available at {}", String.join(", ", httpServer.getHttpAddresses()));
+		}
 		awaitShutdown();
 	}
 

--- a/launchers/http/src/main/java/io/activej/launchers/http/MultithreadedHttpServerLauncher.java
+++ b/launchers/http/src/main/java/io/activej/launchers/http/MultithreadedHttpServerLauncher.java
@@ -117,8 +117,8 @@ public abstract class MultithreadedHttpServerLauncher extends Launcher {
 	@Override
 	protected void run() throws Exception {
 		logger.info("HTTP Server is listening on {}", Stream.concat(
-						primaryServer.getListenAddresses().stream().map(address -> "http://" + ("0.0.0.0".equals(address.getHostName()) ? "localhost" : address.getHostName()) + (address.getPort() != 80 ? ":" + address.getPort() : "") + "/"),
-						primaryServer.getSslListenAddresses().stream().map(address -> "https://" + ("0.0.0.0".equals(address.getHostName()) ? "localhost" : address.getHostName()) + (address.getPort() != 80 ? ":" + address.getPort() : "") + "/"))
+						primaryServer.getBoundAddresses().stream().map(address -> "http://" + ("0.0.0.0".equals(address.getHostName()) ? "localhost" : address.getHostName()) + (address.getPort() != 80 ? ":" + address.getPort() : "") + "/"),
+						primaryServer.getSslBoundAddresses().stream().map(address -> "https://" + ("0.0.0.0".equals(address.getHostName()) ? "localhost" : address.getHostName()) + (address.getPort() != 80 ? ":" + address.getPort() : "") + "/"))
 				.collect(joining(" ")));
 		awaitShutdown();
 	}

--- a/launchers/http/src/main/java/io/activej/launchers/http/MultithreadedHttpServerLauncher.java
+++ b/launchers/http/src/main/java/io/activej/launchers/http/MultithreadedHttpServerLauncher.java
@@ -23,6 +23,7 @@ import io.activej.eventloop.inspector.ThrottlingController;
 import io.activej.http.AsyncHttpServer;
 import io.activej.http.AsyncServlet;
 import io.activej.http.HttpResponse;
+import io.activej.http.HttpUtils;
 import io.activej.inject.annotation.Inject;
 import io.activej.inject.annotation.Provides;
 import io.activej.inject.binding.OptionalDependency;
@@ -116,10 +117,12 @@ public abstract class MultithreadedHttpServerLauncher extends Launcher {
 
 	@Override
 	protected void run() throws Exception {
-		logger.info("HTTP Server is listening on {}", Stream.concat(
-						primaryServer.getBoundAddresses().stream().map(address -> "http://" + ("0.0.0.0".equals(address.getHostName()) ? "localhost" : address.getHostName()) + (address.getPort() != 80 ? ":" + address.getPort() : "") + "/"),
-						primaryServer.getSslBoundAddresses().stream().map(address -> "https://" + ("0.0.0.0".equals(address.getHostName()) ? "localhost" : address.getHostName()) + (address.getPort() != 80 ? ":" + address.getPort() : "") + "/"))
-				.collect(joining(" ")));
+		if (logger.isInfoEnabled()) {
+			logger.info("HTTP Server is listening on {}", Stream.concat(
+							primaryServer.getBoundAddresses().stream().map(address -> HttpUtils.formatUrl(address, false)),
+							primaryServer.getSslBoundAddresses().stream().map(address -> HttpUtils.formatUrl(address, true)))
+					.collect(joining(" ")));
+		}
 		awaitShutdown();
 	}
 

--- a/launchers/http/src/test/java/io/activej/launchers/http/HttpServerLauncherTest.java
+++ b/launchers/http/src/test/java/io/activej/launchers/http/HttpServerLauncherTest.java
@@ -1,14 +1,25 @@
 package io.activej.launchers.http;
 
+import io.activej.config.Config;
 import io.activej.http.AsyncServlet;
+import io.activej.http.HttpResponse;
 import io.activej.inject.Injector;
 import io.activej.inject.annotation.Provides;
+import io.activej.launcher.Launcher;
 import io.activej.test.rules.ByteBufRule;
+import io.activej.test.rules.EventloopRule;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import static io.activej.promise.Promise.ofCompletionStage;
+import static io.activej.promise.TestUtils.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
 public class HttpServerLauncherTest {
+	@ClassRule
+	public static final EventloopRule eventloopRule = new EventloopRule();
 	@ClassRule
 	public static final ByteBufRule byteBufRule = new ByteBufRule();
 
@@ -26,5 +37,68 @@ public class HttpServerLauncherTest {
 			}
 		};
 		launcher.testInjector();
+	}
+
+	@Test
+	public void bindZeroPort() {
+		HttpServerLauncher launcher = new HttpServerLauncher() {
+			@Provides
+			AsyncServlet servlet() {
+				return req -> HttpResponse.ok200();
+			}
+
+			@Override
+			Config config() {
+				return super.config().with("http.listenAddresses", "0");
+			}
+		};
+
+		new Thread(() -> {
+			try {
+				launcher.launch(Launcher.NO_ARGS);
+			} catch (Exception e) {
+				throw new AssertionError(e);
+			}
+		}).start();
+
+		await(ofCompletionStage(launcher.getStartFuture()));
+		assertEquals(1, launcher.httpServer.getListenAddresses().size());
+		assertEquals(0, launcher.httpServer.getListenAddresses().get(0).getPort());
+		assertEquals(1, launcher.httpServer.getBoundAddresses().size());
+		assertNotEquals(0, launcher.httpServer.getBoundAddresses().get(0).getPort());
+
+		launcher.shutdown();
+		await(ofCompletionStage(launcher.getCompleteFuture()));
+	}
+
+	@Test
+	public void bindNonZeroPort() {
+		HttpServerLauncher launcher = new HttpServerLauncher() {
+			@Provides
+			AsyncServlet servlet() {
+				return req -> HttpResponse.ok200();
+			}
+		};
+
+		new Thread(() -> {
+			try {
+				launcher.launch(Launcher.NO_ARGS);
+			} catch (Exception e) {
+				throw new AssertionError(e);
+			}
+		}).start();
+
+		await(ofCompletionStage(launcher.getStartFuture()));
+		assertEquals(1, launcher.httpServer.getListenAddresses().size());
+		assertEquals(
+				HttpServerLauncher.PORT,
+				launcher.httpServer.getListenAddresses().get(0).getPort());
+		assertEquals(1, launcher.httpServer.getBoundAddresses().size());
+		assertEquals(
+				HttpServerLauncher.PORT,
+				launcher.httpServer.getBoundAddresses().get(0).getPort());
+
+		launcher.shutdown();
+		await(ofCompletionStage(launcher.getCompleteFuture()));
 	}
 }

--- a/launchers/http/src/test/java/io/activej/launchers/http/MultithreadedHttpServerLauncherTest.java
+++ b/launchers/http/src/test/java/io/activej/launchers/http/MultithreadedHttpServerLauncherTest.java
@@ -1,17 +1,27 @@
 package io.activej.launchers.http;
 
+import io.activej.config.Config;
 import io.activej.http.AsyncServlet;
+import io.activej.http.HttpResponse;
 import io.activej.inject.Injector;
 import io.activej.inject.annotation.Provides;
+import io.activej.launcher.Launcher;
 import io.activej.test.rules.ByteBufRule;
+import io.activej.test.rules.EventloopRule;
 import io.activej.worker.annotation.Worker;
 import io.activej.worker.annotation.WorkerId;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-public class MultithreadedHttpServerLauncherTest {
+import static io.activej.promise.Promise.ofCompletionStage;
+import static io.activej.promise.TestUtils.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
+public class MultithreadedHttpServerLauncherTest {
+	@ClassRule
+	public static final EventloopRule eventloopRule = new EventloopRule();
 	@ClassRule
 	public static final ByteBufRule byteBufRule = new ByteBufRule();
 
@@ -30,5 +40,64 @@ public class MultithreadedHttpServerLauncherTest {
 			}
 		};
 		launcher.testInjector();
+	}
+
+	@Test
+	public void bindZeroPort() {
+		MultithreadedHttpServerLauncher launcher = new MultithreadedHttpServerLauncher() {
+			@Provides
+			AsyncServlet servlet() {
+				return req -> HttpResponse.ok200();
+			}
+
+			@Override
+			Config config() {
+				return super.config().with("http.listenAddresses", "0");
+			}
+		};
+
+		new Thread(() -> {
+			try {
+				launcher.launch(Launcher.NO_ARGS);
+			} catch (Exception e) {
+				throw new AssertionError(e);
+			}
+		}).start();
+
+		await(ofCompletionStage(launcher.getStartFuture()));
+		assertEquals(0, launcher.primaryServer.getListenAddresses().get(0).getPort());
+		assertNotEquals(0, launcher.primaryServer.getBoundAddresses().get(0).getPort());
+
+		launcher.shutdown();
+		await(ofCompletionStage(launcher.getCompleteFuture()));
+	}
+
+	@Test
+	public void bindNonZeroPort() {
+		MultithreadedHttpServerLauncher launcher = new MultithreadedHttpServerLauncher() {
+			@Provides
+			AsyncServlet servlet() {
+				return req -> HttpResponse.ok200();
+			}
+		};
+
+		new Thread(() -> {
+			try {
+				launcher.launch(Launcher.NO_ARGS);
+			} catch (Exception e) {
+				throw new AssertionError(e);
+			}
+		}).start();
+
+		await(ofCompletionStage(launcher.getStartFuture()));
+		assertEquals(
+				MultithreadedHttpServerLauncher.PORT,
+				launcher.primaryServer.getListenAddresses().get(0).getPort());
+		assertEquals(
+				MultithreadedHttpServerLauncher.PORT,
+				launcher.primaryServer.getBoundAddresses().get(0).getPort());
+
+		launcher.shutdown();
+		await(ofCompletionStage(launcher.getCompleteFuture()));
 	}
 }

--- a/util-common/src/main/java/io/activej/common/StringFormatUtils.java
+++ b/util-common/src/main/java/io/activej/common/StringFormatUtils.java
@@ -380,8 +380,8 @@ public final class StringFormatUtils {
 			throw new MalformedDataException(nfe);
 		}
 
-		if (port <= 0 || port >= 65536) {
-			throw new MalformedDataException("Invalid address. Port is not in range (0, 65536) " + addressStr);
+		if (port < 0 || port >= 65536) {
+			throw new MalformedDataException("Invalid address. Port is not in range [0, 65536) " + addressStr);
 		}
 		if ("*".equals(addressStr)) {
 			return new InetSocketAddress(port);


### PR DESCRIPTION
This PR changes `AbstractServer` to allow port number zero so that the system will pick a free port number. I find that useful for testing and was surprised that ActiveJ doesn't allow this yet.

Usages of `io.activej.test.TestUtils#getFreePort` remain untouched but I added new tests that use port number zero.

The dynamic port number picked up by the system is available via `AbstractServer#get[Ssl]BoundAddresses()`. I couldn't come up with a better name to distinguish from the existing `get[Ssl]ListenAddresses()`. Feel free to suggest a better name.

In this context I also noticed that the URLs logged by `HttpServerLauncher` and `MultithreadedHttpServerLauncher` once they become available are not correct:
* `MultithreadedHttpServerLauncher` used port 80 as default for HTTPS.
* IPv4 address `0.0.0.0` instead of `127.0.0.1` was mapped to `localhost`.
* IPv6 addresses were not enclosed in square brackets (RFC 2732).

I addressed these issues in a separate commit by factoring out the formatting and relying solely on the hostname returned by `InetAddress#getHostName()`.