### PR TITLE
Fix routing of percent-encoded HTTP URLs

### DIFF
--- a/core-http/src/main/java/io/activej/http/HttpRequest.java
+++ b/core-http/src/main/java/io/activej/http/HttpRequest.java
@@ -370,7 +370,7 @@ public final class HttpRequest extends HttpMessage implements WithInitializer<Ht
 		if (pathParameters == null) {
 			pathParameters = new HashMap<>();
 		}
-		pathParameters.put(key, UrlParser.urlParse(value));
+		pathParameters.put(key, value);
 	}
 
 	@Override

--- a/core-http/src/main/java/io/activej/http/RoutingServlet.java
+++ b/core-http/src/main/java/io/activej/http/RoutingServlet.java
@@ -175,7 +175,7 @@ public final class RoutingServlet implements AsyncServlet, WithInitializer<Routi
 
 	private @Nullable Promise<HttpResponse> tryServe(HttpRequest request) throws Exception {
 		int introPosition = request.getPos();
-		String urlPart = UrlParser.urlParse(request.pollUrlPart());
+		String urlPart = request.pollUrlPart();
 		if (urlPart == null) {
 			throw HttpError.badRequest400("Path contains bad percent encoding");
 		}

--- a/core-http/src/main/java/io/activej/http/UrlParser.java
+++ b/core-http/src/main/java/io/activej/http/UrlParser.java
@@ -466,19 +466,17 @@ public final class UrlParser {
 		return new String(raw, pos, pathEnd - pos, CHARSET);
 	}
 
-	String pollUrlPart() {
+	@Nullable String pollUrlPart() {
 		if (pos < pathEnd) {
 			int start = pos + 1;
 			int nextSlash = indexOf(SLASH, start);
 			pos = nextSlash > pathEnd ? pathEnd : (short) nextSlash;
-			String part;
 			if (pos == -1) {
-				part = new String(raw, start, pathEnd - start, CHARSET);
 				pos = limit;
+				return urlParse(raw, start, pathEnd);
 			} else {
-				part = new String(raw, start, pos - start, CHARSET);
+				return urlParse(raw, start, pos);
 			}
-			return part;
 		} else {
 			return "";
 		}

--- a/core-http/src/test/java/io/activej/http/HttpUrlTest.java
+++ b/core-http/src/test/java/io/activej/http/HttpUrlTest.java
@@ -170,6 +170,21 @@ public final class HttpUrlTest {
 	}
 
 	@Test
+	public void testPollUrlPartWithPercentEncoding() {
+		UrlParser uri = UrlParser.of("http://example.com/a%2f/b%2F");
+		assertEquals("a/", uri.pollUrlPart());
+		assertEquals("/b%2F", uri.getPartialPath());
+		assertEquals("b/", uri.pollUrlPart());
+		assertEquals("", uri.pollUrlPart());
+	}
+
+	@Test
+	public void testPollUrlPartWithBadPercentEncoding() {
+		UrlParser uri = UrlParser.of("http://example.com/a%2");
+		assertNull("a/", uri.pollUrlPart());
+	}
+
+	@Test
 	public void testPollUrlPartWithNotUrlEncodedQuery() throws MalformedHttpException {
 		UrlParser url = UrlParser.parse("/category/url?url=http://example.com");
 		assertEquals("category", url.pollUrlPart());

--- a/core-http/src/test/java/io/activej/http/RoutingServletTest.java
+++ b/core-http/src/test/java/io/activej/http/RoutingServletTest.java
@@ -6,6 +6,8 @@ import io.activej.test.rules.ByteBufRule;
 import org.junit.ClassRule;
 import org.junit.Test;
 
+import java.util.TreeMap;
+
 import static io.activej.bytebuf.ByteBufStrings.wrapUtf8;
 import static io.activej.http.HttpMethod.*;
 import static io.activej.http.WebSocketConstants.NOT_A_WEB_SOCKET_REQUEST;
@@ -373,4 +375,72 @@ public final class RoutingServletTest {
 		check(main.serve(HttpRequest.post(TEMPLATE + wsPath)), "", 404);
 	}
 
+	@Test
+	public void testPercentEncoding() throws Exception {
+		RoutingServlet router = RoutingServlet.create();
+
+		AsyncServlet servlet = request -> HttpResponse.ofCode(200).withBody("".getBytes(UTF_8));
+
+		router.map(GET, "/a%2fb", servlet);
+
+		assertThrows(
+				"Already mapped",
+				IllegalArgumentException.class,
+				() -> router.map(GET, "/a%2Fb", servlet)
+		);
+
+		check(router.serve(HttpRequest.get("http://some-test.com/a%2fb")), "", 200);
+		check(router.serve(HttpRequest.get("http://some-test.com/a%2Fb")), "", 200);
+		check(router.serve(HttpRequest.get("http://some-test.com/a/b")), "", 404);
+	}
+
+	@Test
+	public void testPercentEncodedParameters() throws Exception {
+		AsyncServlet printParameters = request -> {
+			String body = new TreeMap<>(request.getPathParameters()).toString();
+			ByteBuf bodyByteBuf = wrapUtf8(body);
+			return HttpResponse.ofCode(200).withBody(bodyByteBuf);
+		};
+
+		RoutingServlet main = RoutingServlet.create()
+				.map(GET, "/a/:val", printParameters);
+
+		check(main.serve(HttpRequest.get("http://example.com/a/1%2f")), "{val=1/}", 200);
+		check(main.serve(HttpRequest.get("http://example.com/a/1%2F")), "{val=1/}", 200);
+		check(main.serve(HttpRequest.get("http://example.com/a/1+")), "{val=1 }", 200);
+		check(main.serve(HttpRequest.get("http://example.com/a/1%252f")), "{val=1%2f}", 200);
+	}
+
+	@Test
+	public void testPercentEncodedParameterName() throws Exception {
+		AsyncServlet printParameters = request -> {
+			String body = new TreeMap<>(request.getPathParameters()).toString();
+			ByteBuf bodyByteBuf = wrapUtf8(body);
+			return HttpResponse.ofCode(200).withBody(bodyByteBuf);
+		};
+
+		RoutingServlet main = RoutingServlet.create()
+				.map(GET, "/a/:%2f", printParameters);
+
+		check(main.serve(HttpRequest.get("http://example.com/a/23")), "{%2f=23}", 200);
+	}
+
+	@Test
+	public void testBadPercentEncoding() {
+		RoutingServlet router = RoutingServlet.create();
+		AsyncServlet servlet = request -> HttpResponse.ofCode(200).withBody(new byte[0]);
+		RoutingServlet main = router.map(GET, "/a", servlet);
+
+		assertThrows(
+				"Path contains bad percent encoding",
+				HttpError.class,
+				() -> main.serve(HttpRequest.get("http://example.com/a%2"))
+		);
+
+		assertThrows(
+				"Path contains bad percent encoding",
+				IllegalArgumentException.class,
+				() -> router.map(GET, "/a%2", servlet)
+		);
+	}
 }


### PR DESCRIPTION
Percent-encoded HTTP URLs are not properly handled. Path segments are not encoded unless they are path parameters extracted from request URLs. 

This PR changes 'RoutingServlet` such that path segments are always decoded when constructing the routes and when handling requests.