### PR TITLE
Make HttpRequest and HttpResponse classes extendable

### DIFF
--- a/core-http/src/main/java/io/activej/http/HttpMessage.java
+++ b/core-http/src/main/java/io/activej/http/HttpMessage.java
@@ -75,7 +75,7 @@ public abstract class HttpMessage {
 	protected int maxBodySize;
 	protected Map<Object, Object> attachments;
 
-	protected HttpMessage(HttpVersion version) {
+	public HttpMessage(HttpVersion version) {
 		this.version = version;
 	}
 

--- a/core-http/src/main/java/io/activej/http/HttpRequest.java
+++ b/core-http/src/main/java/io/activej/http/HttpRequest.java
@@ -65,7 +65,7 @@ public class HttpRequest extends HttpMessage implements ToPromise<HttpRequest> {
 	private Map<String, String> queryParameters;
 	private Map<String, String> postParameters;
 
-	HttpRequest(HttpVersion version, HttpMethod method, UrlParser url, @Nullable HttpServerConnection connection) {
+	public HttpRequest(HttpVersion version, HttpMethod method, UrlParser url, @Nullable HttpServerConnection connection) {
 		super(version);
 		this.method = method;
 		this.url = url;

--- a/core-http/src/main/java/io/activej/http/HttpRequest.java
+++ b/core-http/src/main/java/io/activej/http/HttpRequest.java
@@ -51,7 +51,7 @@ import static io.activej.http.Protocol.WSS;
  * {@code HttpRequest} class provides methods which can be used intuitively for
  * creating and configuring an HTTP request.
  */
-public final class HttpRequest extends HttpMessage implements ToPromise<HttpRequest> {
+public class HttpRequest extends HttpMessage implements ToPromise<HttpRequest> {
 	private static final boolean CHECKS = Checks.isEnabled(HttpRequest.class);
 
 	private static final int LONGEST_HTTP_METHOD_SIZE = 12;

--- a/core-http/src/main/java/io/activej/http/HttpResponse.java
+++ b/core-http/src/main/java/io/activej/http/HttpResponse.java
@@ -41,7 +41,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Represents HTTP response for {@link HttpRequest}. After handling {@code HttpResponse} will be recycled, so you cannot
  * usi it afterwards.
  */
-public final class HttpResponse extends HttpMessage implements ToPromise<HttpResponse> {
+public class HttpResponse extends HttpMessage implements ToPromise<HttpResponse> {
 	private static final boolean CHECKS = Checks.isEnabled(HttpResponse.class);
 
 	private static final byte[] HTTP11_BYTES = encodeAscii("HTTP/1.1 ");

--- a/core-http/src/main/java/io/activej/http/HttpResponse.java
+++ b/core-http/src/main/java/io/activej/http/HttpResponse.java
@@ -116,13 +116,13 @@ public class HttpResponse extends HttpMessage implements ToPromise<HttpResponse>
 
 	private @Nullable Map<String, HttpCookie> parsedCookies;
 
-	HttpResponse(HttpVersion version, int code, @Nullable HttpClientConnection connection) {
+	public HttpResponse(HttpVersion version, int code, @Nullable HttpClientConnection connection) {
 		super(version);
 		this.code = code;
 		this.connection = connection;
 	}
 
-	HttpResponse(HttpVersion version, int code) {
+	public HttpResponse(HttpVersion version, int code) {
 		this(version, code, null);
 	}
 


### PR DESCRIPTION
Make HttpRequest and HttpResponse classes non-final so that they can be extended as needed.
#feature/non-final