### PR TITLE
Fix NPE in doAccept method by checking if sslContext available (#312)

### DIFF
--- a/core-net/src/main/java/io/activej/net/AbstractReactiveServer.java
+++ b/core-net/src/main/java/io/activej/net/AbstractReactiveServer.java
@@ -352,6 +352,7 @@ public abstract class AbstractReactiveServer extends AbstractNioReactive
 	) {
 		assert reactor.inReactorThread();
 		accepts.recordEvent();
+		ssl = (sslContext != null) && ssl;
 		if (ssl) acceptsSsl.recordEvent();
 		InetAddress remoteAddress = remoteSocketAddress.getAddress();
 		onAccept(socketChannel, localAddress, remoteAddress, ssl);


### PR DESCRIPTION
This pull request aims to address a critical issue related to a NullPointerException that occurs when the PrimaryServer, which has an sslContext object, passes a request to one of the worker servers, that don't have an sslContext object. This results in the createSSLEngine method being called on a null object, leading to the NPE.

```
java.lang.NullPointerException: Cannot invoke "javax.net.ssl.SSLContext.createSSLEngine()" because "sslContext" is null
	at io.activej.net.socket.tcp.SslTcpSocket.wrapServerSocket(SslTcpSocket.java:97) ~[main/:?]
	at io.activej.net.AbstractReactiveServer.doAccept(AbstractReactiveServer.java:373) ~[main/:?]
```