### PR TITLE
Improve ByteBufStringsTest Class

### DIFF
--- a/core-bytebuf/src/test/java/io/activej/bytebuf/ByteBufStringsTest.java
+++ b/core-bytebuf/src/test/java/io/activej/bytebuf/ByteBufStringsTest.java
@@ -3,14 +3,14 @@ package io.activej.bytebuf;
 import io.activej.common.exception.MalformedDataException;
 import org.junit.Test;
 
-import java.util.Arrays;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import static io.activej.bytebuf.ByteBufStrings.decodeUtf8;
 import static io.activej.bytebuf.ByteBufStrings.encodeLong;
 import static io.activej.bytebuf.ByteBufTest.initByteBufPool;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThrows;
 
 public class ByteBufStringsTest {
 	static {
@@ -24,87 +24,92 @@ public class ByteBufStringsTest {
 		ByteBuf buf = ByteBuf.wrapForWriting(new byte[20]);
 
 		// Test edge cases
-		encodeLongTest(buf, Long.MAX_VALUE);
-		encodeLongTest(buf, Long.MIN_VALUE);
+		assertEncodeLong(buf, Long.MAX_VALUE);
+		assertEncodeLong(buf, Long.MIN_VALUE);
 
 		// Test random values
-		long value = RANDOM.nextLong();
-		byte[] bytes = String.valueOf(value).getBytes();
-		Arrays.fill(bytes, (byte) 0);
-		buf = ByteBuf.wrapForWriting(bytes);
-		encodeLongTest(buf, value);
+		for (int i = 0; i < 10; i++) { // Run multiple random tests for better coverage
+			long value = RANDOM.nextLong();
+			buf = ByteBuf.wrapForWriting(new byte[20]); // Reset buffer for each test
+			assertEncodeLong(buf, value);
+		}
 	}
 
 	@Test
 	public void testDecodeInt() throws MalformedDataException {
 		// Test edge cases
-		decodeIntTest(Integer.MAX_VALUE);
-		decodeIntTest(Integer.MIN_VALUE);
+		assertDecodeInt(Integer.MAX_VALUE);
+		assertDecodeInt(Integer.MIN_VALUE);
 
 		// Test random values
-		decodeIntTest(RANDOM.nextInt());
+		for (int i = 0; i < 10; i++) { // Run multiple random tests for better coverage
+			assertDecodeInt(RANDOM.nextInt());
+		}
 	}
 
 	@Test
 	public void testDecodeLong() throws MalformedDataException {
 		// Test edge cases
-		decodeLongTest(Long.MAX_VALUE);
-		decodeLongTest(Long.MIN_VALUE);
+		assertDecodeLong(Long.MAX_VALUE);
+		assertDecodeLong(Long.MIN_VALUE);
 
 		// Test random values
-		decodeLongTest(RANDOM.nextLong());
+		for (int i = 0; i < 10; i++) { // Run multiple random tests for better coverage
+			assertDecodeLong(RANDOM.nextLong());
+		}
 
 		// Test with offset
 		String string = "-1234567891234";
-		byte[] bytesRepr = string.getBytes();
+		byte[] bytesRepr = string.getBytes(StandardCharsets.UTF_8);
 		long decoded = ByteBufStrings.decodeLong(bytesRepr, 0, string.length());
 		assertEquals(-1234567891234L, decoded);
 
-		// Test bigger than long
-		try {
-			string = "92233720368547758081242123";
-			bytesRepr = string.getBytes();
-			ByteBufStrings.decodeLong(bytesRepr, 0, string.length());
-			fail();
-		} catch (MalformedDataException e) {
-			assertEquals("Bigger than max long value: 92233720368547758081242123", e.getMessage());
-		}
+		// Test with value bigger than Long.MAX_VALUE
+		String largeNumber = "92233720368547758081242123";
+		byte[] largeBytes = largeNumber.getBytes(StandardCharsets.UTF_8);
+		MalformedDataException exception = assertThrows(MalformedDataException.class,
+			() -> ByteBufStrings.decodeLong(largeBytes, 0, largeNumber.length()));
+		assertEquals("Bigger than max long value: 92233720368547758081242123", exception.getMessage());
 	}
 
 	@Test
 	public void testWrapLong() throws MalformedDataException {
 		// Test edge cases
-		ByteBuf byteBuf = ByteBufStrings.wrapLong(Long.MAX_VALUE);
-		assertEquals(String.valueOf(Long.MAX_VALUE), ByteBufStrings.decodeUtf8(byteBuf));
+		assertWrapLong(Long.MAX_VALUE);
+		assertWrapLong(Long.MIN_VALUE);
 
-		byteBuf = ByteBufStrings.wrapLong(Long.MIN_VALUE);
-		assertEquals(String.valueOf(Long.MIN_VALUE), ByteBufStrings.decodeUtf8(byteBuf));
-
-		long value = RANDOM.nextLong();
-		byteBuf = ByteBufStrings.wrapLong(value);
-		assertEquals(String.valueOf(value), ByteBufStrings.decodeUtf8(byteBuf));
+		// Test random values
+		for (int i = 0; i < 10; i++) { // Run multiple random tests for better coverage
+			assertWrapLong(RANDOM.nextLong());
+		}
 	}
 
-	// region helpers
-	private void encodeLongTest(ByteBuf buf, long value) throws MalformedDataException {
+	// region Helper Methods
+	private void assertEncodeLong(ByteBuf buf, long value) throws MalformedDataException {
 		buf.rewind();
-		buf.moveTail(encodeLong(buf.array, buf.head(), value));
+		buf.moveTail(encodeLong(buf.array(), buf.head(), value));
 		String stringRepr = decodeUtf8(buf);
-		assertEquals(String.valueOf(value), stringRepr);
+		assertEquals("Encoded value did not match the expected string representation", String.valueOf(value), stringRepr);
 	}
 
-	private void decodeIntTest(int value) throws MalformedDataException {
+	private void assertDecodeInt(int value) throws MalformedDataException {
 		String string = String.valueOf(value);
-		byte[] bytesRepr = string.getBytes();
+		byte[] bytesRepr = string.getBytes(StandardCharsets.UTF_8);
 		int decoded = ByteBufStrings.decodeInt(bytesRepr, 0, string.length());
-		assertEquals(value, decoded);
+		assertEquals("Decoded value did not match the original", value, decoded);
 	}
 
-	private void decodeLongTest(long value) throws MalformedDataException {
+	private void assertDecodeLong(long value) throws MalformedDataException {
 		String string = String.valueOf(value);
-		byte[] bytesRepr = string.getBytes();
+		byte[] bytesRepr = string.getBytes(StandardCharsets.UTF_8);
 		long decoded = ByteBufStrings.decodeLong(bytesRepr, 0, string.length());
-		assertEquals(value, decoded);
+		assertEquals("Decoded value did not match the original", value, decoded);
+	}
+
+	private void assertWrapLong(long value) throws MalformedDataException {
+		ByteBuf byteBuf = ByteBufStrings.wrapLong(value);
+		String decodedString = ByteBufStrings.decodeUtf8(byteBuf);
+		assertEquals("Wrapped value did not match the expected string representation", String.valueOf(value), decodedString);
 	}
 	// endregion
 }


### PR DESCRIPTION
### Improvements Which Have Been Made:

1. **Readable Method Names**: Changed helper method names to `assertEncodeLong`, `assertDecodeInt`, etc.
2. **Improved Assertions**: Added descriptive messages to assertions for better clarity on what went wrong.
3. **Multiple Random Tests**: Instead of a single random test, now running multiple random tests to better validate functionality.
4. **Standard Charset Usage**: Explicitly used `StandardCharsets.UTF_8` for clarity.
5. **Testing for Failures**: Used `assertThrows` to validate failure scenarios, which is more concise and readable.