### PR TITLE
Support OpenTelemetry semantic conventions http route attribute - http.route - Fix #339

### DIFF
--- a/core-http/src/main/java/io/activej/http/HttpRequest.java
+++ b/core-http/src/main/java/io/activej/http/HttpRequest.java
@@ -58,6 +58,7 @@ public final class HttpRequest extends HttpMessage implements ToPromise<HttpRequ
 	private final UrlParser url;
 	private final HttpServerConnection connection;
 	private InetAddress remoteAddress;
+	private String routePattern;
 	private Map<String, String> pathParameters;
 	private Map<String, String> queryParameters;
 	private Map<String, String> postParameters;
@@ -151,6 +152,25 @@ public final class HttpRequest extends HttpMessage implements ToPromise<HttpRequ
 	public String getPath() {
 		if (CHECKS) checkState(!isRecycled());
 		return url.getPath();
+	}
+
+	public String getRoutePattern() {
+		if (CHECKS) checkState(!isRecycled());
+		return checkNotNull(routePattern, "Route pattern not set - was this request routed through RoutingServlet?");
+	}
+
+	@Nullable String routePattern() {
+		return routePattern;
+	}
+
+	void setRoutePattern(@Nullable String routePattern) {
+		if (CHECKS) checkState(!isRecycled());
+		this.routePattern = routePattern;
+	}
+
+	void appendRoutePattern(String pathSegment) {
+		if (CHECKS) checkState(!isRecycled());
+		this.routePattern = this.routePattern == null ? pathSegment : this.routePattern + pathSegment;
 	}
 
 	public String getPathAndQuery() {

--- a/core-http/src/main/java/io/activej/http/RoutingServlet.java
+++ b/core-http/src/main/java/io/activej/http/RoutingServlet.java
@@ -174,20 +174,27 @@ public final class RoutingServlet extends AbstractReactive
 		if (urlPart.isEmpty()) {
 			AsyncServlet servlet = getOrDefault(servlets, ordinal);
 			if (servlet != null) {
+				if (request.routePattern() == null) {
+					request.setRoutePattern("/");
+				}
 				return servlet.serve(request);
 			}
 		} else {
 			int position = request.getPos();
+			String savedRoutePattern = request.routePattern();
 			RoutingServlet transit = routes.get(urlPart);
 			if (transit != null) {
+				request.appendRoutePattern("/" + urlPart);
 				Promise<HttpResponse> result = transit.tryServe(request);
 				if (result != null) {
 					return result;
 				}
 				request.setPos(position);
+				request.setRoutePattern(savedRoutePattern);
 			}
 			for (Entry<String, RoutingServlet> entry : parameters.entrySet()) {
 				String key = entry.getKey();
+				request.appendRoutePattern("/{" + key + "}");
 				request.putPathParameter(key, urlPart);
 				Promise<HttpResponse> result = entry.getValue().tryServe(request);
 				if (result != null) {
@@ -195,12 +202,14 @@ public final class RoutingServlet extends AbstractReactive
 				}
 				request.removePathParameter(key);
 				request.setPos(position);
+				request.setRoutePattern(savedRoutePattern);
 			}
 		}
 
 		AsyncServlet servlet = getOrDefault(fallbackServlets, ordinal);
 		if (servlet != null) {
 			request.setPos(introPosition);
+			request.appendRoutePattern("/*");
 			return servlet.serve(request);
 		}
 		return null;

--- a/core-http/src/test/java/io/activej/http/RoutingServletTest.java
+++ b/core-http/src/test/java/io/activej/http/RoutingServletTest.java
@@ -500,4 +500,37 @@ public final class RoutingServletTest {
 		HttpError e = assertThrows(HttpError.class, () -> router.serve(HttpRequest.get("http://example.com/a%2").build()));
 		assertEquals("HTTP code 400: Path contains bad percent encoding", e.getMessage());
 	}
+
+	@Test
+	public void testRoutePattern() throws Exception {
+		RoutingServlet servlet = RoutingServlet.builder(getCurrentReactor())
+			.with(GET, "/user/:id", request -> {
+				ByteBuf body = wrapUtf8(request.getRoutePattern());
+				return HttpResponse.ofCode(200).withBody(body).toPromise();
+			})
+			.with(GET, "/orders/:orderId/items/:itemId", request -> {
+				ByteBuf body = wrapUtf8(request.getRoutePattern());
+				return HttpResponse.ofCode(200).withBody(body).toPromise();
+			})
+			.with(GET, "/static/path", request -> {
+				ByteBuf body = wrapUtf8(request.getRoutePattern());
+				return HttpResponse.ofCode(200).withBody(body).toPromise();
+			})
+			.with(GET, "/wildcard/*", request -> {
+				ByteBuf body = wrapUtf8(request.getRoutePattern());
+				return HttpResponse.ofCode(200).withBody(body).toPromise();
+			})
+			.with(GET, "/", request -> {
+				ByteBuf body = wrapUtf8(request.getRoutePattern());
+				return HttpResponse.ofCode(200).withBody(body).toPromise();
+			})
+			.build();
+
+		check(servlet.serve(HttpRequest.get(TEMPLATE + "/user/123").build()), "/user/{id}", 200);
+		check(servlet.serve(HttpRequest.get(TEMPLATE + "/user/456").build()), "/user/{id}", 200);
+		check(servlet.serve(HttpRequest.get(TEMPLATE + "/orders/789/items/abc").build()), "/orders/{orderId}/items/{itemId}", 200);
+		check(servlet.serve(HttpRequest.get(TEMPLATE + "/static/path").build()), "/static/path", 200);
+		check(servlet.serve(HttpRequest.get(TEMPLATE + "/wildcard/anything/here").build()), "/wildcard/*", 200);
+		check(servlet.serve(HttpRequest.get(TEMPLATE + "/").build()), "/", 200);
+	}
 }


### PR DESCRIPTION
Fix for #339 

Add route pattern tracking to `RoutingServlet` and `HttpRequest` to support opentelemetry http attribute `http.route`

- Introduced the ability to track and modify route patterns in `HttpRequest`.
- Updated `RoutingServlet` to utilize route patterns, enabling more detailed routing logic.
- Added unit tests validating the new route pattern functionality.