### PR TITLE
Fix BlockingSocketServer.stop() to close all ServerSockets on failure

### DIFF
--- a/core-eventloop/src/main/java/io/activej/reactor/net/BlockingSocketServer.java
+++ b/core-eventloop/src/main/java/io/activej/reactor/net/BlockingSocketServer.java
@@ -142,14 +142,26 @@ public final class BlockingSocketServer {
 	}
 
 	public void stop() throws Exception {
-		for (ServerSocket serverSocket : serverSockets) {
-			Thread acceptThread = acceptThreads.get(serverSocket);
-			acceptThread.interrupt();
-			serverSocket.close();
-		}
-		for (Thread acceptThread : acceptThreads.values()) {
-			acceptThread.join();
-		}
-		serverSockets.clear();
-	}
+        IOException first = null;
+        for (ServerSocket serverSocket : serverSockets) {
+            Thread acceptThread = acceptThreads.get(serverSocket);
+            acceptThread.interrupt();
+            try {
+                serverSocket.close();
+            } catch (IOException e) {
+                if (first == null) {
+                    first = e;
+                } else {
+                    first.addSuppressed(e);
+                }
+            }
+        }
+        for (Thread acceptThread : acceptThreads.values()) {
+            acceptThread.join();
+        }
+        serverSockets.clear();
+        if (first != null) {
+            throw first;
+        }
+    }
 }


### PR DESCRIPTION
**Problem**
`BlockingSocketServer.stop()` closed server sockets sequentially. If one `ServerSocket.close()` threw an `IOException`, the method would exit early and leave remaining sockets open.

**Fix**
Make `stop()` exception-safe by attempting to close all server sockets, collecting the first `IOException` and suppressing subsequent close failures, then throwing after cleanup is complete.
